### PR TITLE
Add `thread::sleep` to wait for routing table lock to be freed

### DIFF
--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -623,9 +623,15 @@ impl Node {
     }
 
     /// Returns a reference to the `RoutingTable` associated with the node.
+    /// TODO: Currently returns a clone. WARN: Possible infinite recursion. Refactor this immediately after alphanet.
     pub fn get_routing_table(&self) -> RoutingTable {
         // TODO: address unwrap later
-        self.routing_table.try_lock().unwrap().clone()
+        if let Ok(table) = self.routing_table.try_lock() {
+            return table.to_owned();
+        } else {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            self.get_routing_table()
+        }
     }
 
     /// Returns the `NodeData` associated with the node.


### PR DESCRIPTION
Puts a thread to sleep to wait on a lock for the routing table. This will need to be refactored after alphanet to avoid possible infinite recursion. For now this is a quick fix that will allow quorums to be formed.